### PR TITLE
Task: allow converting to inner async_task::JoinHandle

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,14 @@ impl<T> Future for Task<T> {
     }
 }
 
+impl<T> Into<async_task::JoinHandle<T, ()>> for Task<T> {
+    fn into(mut self) -> async_task::JoinHandle<T, ()> {
+        self.0
+            .take()
+            .expect("task was already canceled or has failed")
+    }
+}
+
 scoped_thread_local! {
     static WORKER: Worker
 }


### PR DESCRIPTION
This is the same as what is done in smol and will help port smol to multitask